### PR TITLE
WIP towards JWK support

### DIFF
--- a/lib/jwt/jwk.rb
+++ b/lib/jwt/jwk.rb
@@ -1,13 +1,16 @@
 # frozen_string_literal: true
 
 require_relative 'jwk/rsa'
+require_relative 'jwk/ec'
 require_relative 'jwk/key_finder'
 
 module JWT
   module JWK
     MAPPINGS = {
       'RSA' => ::JWT::JWK::RSA,
-      OpenSSL::PKey::RSA => ::JWT::JWK::RSA
+      'EC' => ::JWT::JWK::EC,
+      OpenSSL::PKey::RSA => ::JWT::JWK::RSA,
+      OpenSSL::PKey::EC => ::JWT::JWK::EC,
     }.freeze
 
     class << self

--- a/lib/jwt/jwk/ec.rb
+++ b/lib/jwt/jwk/ec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+module JWT
+  module JWK
+    class EC
+      attr_reader :keypair
+
+      KTY    = 'EC'.freeze
+      BINARY = 2
+
+      def initialize(keypair)
+        raise ArgumentError, 'keypair must be of type OpenSSL::PKey::EC' unless keypair.is_a?(OpenSSL::PKey::EC)
+
+        @keypair = keypair
+      end
+
+      def private?
+        keypair.private?
+      end
+
+      def public_key
+        keypair.public_key
+      end
+
+      def export
+        case keypair.group.curve_name
+        when 'prime256v1'; 'P-256'
+          crv = 'P-256'
+          x, y = keypair.public_key.to_bn.to_s(BINARY).unpack('xa32a32')
+        when 'secp384r1';
+          crv = 'P-384'
+          x, y = keypair.public_key.to_bn.to_s(BINARY).unpack('xa48a48')
+        when 'secp521r1'; 'P-521'
+          crv = 'P-521'
+          x, y = keypair.public_key.to_bn.to_s(BINARY).unpack('xa66a66')
+        else
+          raise "error!"
+        end
+        sequence = OpenSSL::ASN1::Sequence([OpenSSL::ASN1::Integer.new(OpenSSL::BN.new(x, BINARY)),
+                                            OpenSSL::ASN1::Integer.new(OpenSSL::BN.new(y, BINARY))])
+        kid = OpenSSL::Digest::SHA256.hexdigest(sequence.to_der)
+        {
+          kty: KTY,
+          crv: crv,
+          x: encode_octets(x),
+          y: encode_octets(y),
+          kid: kid,
+          d: (encode_open_ssl_bn(keypair.private_key) if keypair.private_key?),
+        }.compact
+      end
+
+      def encode_octets(octets)
+        ::Base64.urlsafe_encode64(octets, padding: false)
+      end
+
+      def encode_open_ssl_bn(key_part)
+        ::Base64.urlsafe_encode64(key_part.to_s(BINARY), padding: false)
+      end
+
+      def self.import(jwk_data)
+        jwk_crv = jwk_data[:crv] || jwk_data['crv']
+        jwk_x = jwk_data[:x] || jwk_data['x']
+        jwk_y = jwk_data[:y] || jwk_data['y']
+        jwk_d = jwk_data[:d] || jwk_data['d']
+
+        self.new(ec_pkey(jwk_crv, jwk_x, jwk_y, jwk_d))
+      end
+
+      def self.ec_pkey(jwk_crv, jwk_x, jwk_y, jwk_d=nil)
+        curve = to_openssl_curve(jwk_crv)
+
+        x = decode_octets(jwk_x)
+        y = decode_octets(jwk_y)
+
+        key = OpenSSL::PKey::EC.new(curve)
+
+        point = OpenSSL::PKey::EC::Point.new(
+          OpenSSL::PKey::EC::Group.new(curve),
+          OpenSSL::BN.new([0x04, x, y].pack('Ca*a*'), 2)
+        )
+
+        key.public_key = point
+        key.private_key = decode_open_ssl_bn(jwk_d) if jwk_d
+
+        key
+      end
+
+      def self.to_openssl_curve(crv)
+        # See RFC 5480 section 2.1.1.1 for help in navigating the
+        # different aliases for these curves.
+        case crv
+        when 'P-256'; 'prime256v1'
+        when 'P-384'; 'secp384r1'
+        when 'P-521'; 'secp521r1'
+        else raise 'Invalid curve provided'
+        end
+      end
+
+      def self.decode_octets(jwk_data)
+        ::Base64.urlsafe_decode64(jwk_data)
+      end
+
+      def self.decode_open_ssl_bn(jwk_data)
+        OpenSSL::BN.new(::Base64.urlsafe_decode64(jwk_data), BINARY)
+      end
+    end
+  end
+end

--- a/ruby-jwt.gemspec
+++ b/ruby-jwt.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'codeclimate-test-reporter'
   spec.add_development_dependency 'codacy-coverage'
   spec.add_development_dependency 'rbnacl'
+  spec.add_development_dependency 'byebug'
   # RSASSA-PSS support provided by OpenSSL +2.1
   spec.add_development_dependency 'openssl', '~> 2.1'
 end

--- a/spec/jwk/ec_spec.rb
+++ b/spec/jwk/ec_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require_relative '../spec_helper'
+require 'jwt'
+
+describe JWT::JWK::EC do
+  let(:ec_key) { OpenSSL::PKey::EC.new("secp384r1").generate_key! }
+
+  describe '.new' do
+    subject { described_class.new(keypair) }
+
+    context 'when a keypair with both keys given' do
+      let(:keypair) { ec_key }
+      it 'creates an instance of the class' do
+        expect(subject).to be_a described_class
+        expect(subject.private?).to eq true
+      end
+    end
+
+    context 'when a keypair with only public key is given' do
+      let(:keypair) { ec_key.tap { |x| x.private_key = nil } }
+      it 'creates an instance of the class' do
+        expect(subject).to be_a described_class
+        expect(subject.private?).to eq false
+      end
+    end
+  end
+
+  describe '#export' do
+    subject { described_class.new(keypair).export }
+
+    context 'when keypair with private key is exported' do
+      let(:keypair) { ec_key }
+      it 'returns a hash with the both parts of the key' do
+        expect(subject).to be_a Hash
+        expect(subject).to include(:kty, :kid, :x, :y, :d)
+      end
+    end
+
+    context 'when keypair with public key is exported' do
+      let(:keypair) { ec_key.tap { |x| x.private_key = nil } }
+      it 'returns a hash with the public parts of the key' do
+        expect(subject).to be_a Hash
+        expect(subject).to include(:kty, :kid, :x, :y)
+        expect(subject).not_to include(:d)
+      end
+    end
+  end
+
+  describe '.import' do
+    subject { described_class.import(params) }
+    let(:exported_key) { described_class.new(keypair).export }
+
+    ['P-256', 'P-384', 'P-521'].each do |crv|
+      context "when crv=#{crv}" do
+        let(:openssl_curve) { JWT::JWK::EC.to_openssl_curve(crv) }
+        let(:ec_key) { OpenSSL::PKey::EC.new(openssl_curve).generate_key! }
+
+        context 'when keypair is private' do
+          let(:keypair) { ec_key }
+          let(:params) { exported_key }
+
+          it 'returns a private key' do
+            expect(subject).to be_a described_class
+            expect(subject.private?).to eq true
+            expect(subject.export).to eq(exported_key)
+          end
+        end
+
+        context 'returns a public key' do
+          let(:keypair) { ec_key.tap { |x| x.private_key = nil } }
+          let(:params) { exported_key }
+
+          it 'returns a hash with the public parts of the key' do
+            expect(subject).to be_a described_class
+            expect(subject.private?).to eq false
+            expect(subject.export).to eq(exported_key)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The Ruby docs [1] point us at the OpenSSL docs [2] which have this
to say:

> In addition EC_POINT can be converted to and from various external
> representations. The octet form is the binary encoding of the ECPoint
> structure (as defined in RFC5480 and used in certificates and TLS
> records): only the content octets are present, the OCTET STRING tag
> and length are not included.

We follow it to RFC5480's section 2.2 [3]:
> The subjectPublicKey from SubjectPublicKeyInfo is the ECC public key.
> ECC public keys have the following syntax:
>
>   ECPoint ::= OCTET STRING
>
> Implementations of Elliptic Curve Cryptography according to this
> document MUST support the uncompressed form and MAY support the
> compressed form of the ECC public key.  The hybrid form of the ECC
> public key from [X9.62] MUST NOT be used.  As specified in [SEC1]:
>
>    * The elliptic curve public key (a value of type ECPoint that is
>      an OCTET STRING) is mapped to a subjectPublicKey (a value of
>      type BIT STRING) as follows: the most significant bit of the
>      OCTET STRING value becomes the most significant bit of the BIT
>      STRING value, and so on; the least significant bit of the OCTET
>      STRING becomes the least significant bit of the BIT STRING.
>      Conversion routines are found in Sections 2.3.1 and 2.3.2 of
>      [SEC1].
>
>    * The first octet of the OCTET STRING indicates whether the key is
>      compressed or uncompressed.  The uncompressed form is indicated
>      by 0x04 and the compressed form is indicated by either 0x02 or
>      0x03 (see 2.3.3 in [SEC1]).  The public key MUST be rejected if
>      any other value is included in the first octet.

We follow the reference to SEC1 [4] and find that they expect the
point to be encoded as $ {04}_{16} || X || Y $.

This is how we end up with the magic incantation of
```
FIXME [0x04, x, y].pack('Ca*a*')
```
to create the point.

[1] https://docs.ruby-lang.org/en/2.4.0/OpenSSL/PKey/EC.html
[2] https://www.openssl.org/docs/manmaster/man3/EC_POINT_new.html
[3] https://tools.ietf.org/html/rfc5480#section-2.2
[4] https://www.secg.org/SEC1-Ver-1.0.pdf

Other References:
- https://github.com/potatosalad/ruby-jose/blob/master/lib/jose/jwk/kty_ec.rb#L22
- https://tools.ietf.org/html/rfc7517 - RFC for JWK
- https://tools.ietf.org/html/rfc7518#section-6.2.1 - RFC with specifics
about EC JWK stuff.