### PR TITLE
Add support for JWKs with EC key type

### DIFF
--- a/lib/jwt/jwk.rb
+++ b/lib/jwt/jwk.rb
@@ -1,13 +1,16 @@
 # frozen_string_literal: true
 
 require_relative 'jwk/rsa'
+require_relative 'jwk/ec'
 require_relative 'jwk/key_finder'
 
 module JWT
   module JWK
     MAPPINGS = {
       'RSA' => ::JWT::JWK::RSA,
-      OpenSSL::PKey::RSA => ::JWT::JWK::RSA
+      'EC' => ::JWT::JWK::EC,
+      OpenSSL::PKey::RSA => ::JWT::JWK::RSA,
+      OpenSSL::PKey::EC => ::JWT::JWK::EC
     }.freeze
 
     class << self

--- a/lib/jwt/jwk/ec.rb
+++ b/lib/jwt/jwk/ec.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+module JWT
+  module JWK
+    class EC
+      extend Forwardable
+      def_delegators :@keypair, :private?, :public_key
+
+      attr_reader :keypair
+
+      KTY    = 'EC'
+      BINARY = 2
+
+      def initialize(keypair)
+        raise ArgumentError, 'keypair must be of type OpenSSL::PKey::EC' unless keypair.is_a?(OpenSSL::PKey::EC)
+
+        @keypair = keypair
+      end
+
+      def export
+        crv, x_octets, y_octets = keypair_components
+        sequence = OpenSSL::ASN1::Sequence([OpenSSL::ASN1::Integer.new(OpenSSL::BN.new(x_octets, BINARY)),
+                                            OpenSSL::ASN1::Integer.new(OpenSSL::BN.new(y_octets, BINARY))])
+        kid = OpenSSL::Digest::SHA256.hexdigest(sequence.to_der)
+        {
+          kty: KTY,
+          crv: crv,
+          x: encode_octets(x_octets),
+          y: encode_octets(y_octets),
+          kid: kid
+        }
+      end
+
+      private
+
+      def keypair_components
+        encoded_point = keypair.public_key.to_bn.to_s(BINARY)
+        case keypair.group.curve_name
+        when 'prime256v1'
+          crv = 'P-256'
+          x_octets, y_octets = encoded_point.unpack('xa32a32')
+        when 'secp384r1'
+          crv = 'P-384'
+          x_octets, y_octets = encoded_point.unpack('xa48a48')
+        when 'secp521r1'
+          crv = 'P-521'
+          x_octets, y_octets = encoded_point.unpack('xa66a66')
+        else
+          raise "Unsupported curve '#{keypair.group.curve_name}'"
+        end
+        [crv, x_octets, y_octets]
+      end
+
+      def encode_octets(octets)
+        ::Base64.urlsafe_encode64(octets, padding: false)
+      end
+
+      def encode_open_ssl_bn(key_part)
+        ::Base64.urlsafe_encode64(key_part.to_s(BINARY), padding: false)
+      end
+
+      class << self
+        def import(jwk_data)
+          # See https://tools.ietf.org/html/rfc7518#section-6.2.1 for an
+          # explanation of the relevant parameters.
+
+          jwk_crv, jwk_x, jwk_y = jwk_attrs(jwk_data, %i[crv x y])
+          raise Jwt::JWKError, 'Key format is invalid for EC' unless jwk_crv && jwk_x && jwk_y
+
+          new(ec_pkey(jwk_crv, jwk_x, jwk_y))
+        end
+
+        def to_openssl_curve(crv)
+          # The JWK specs and OpenSSL use different names for the same curves.
+          # See https://tools.ietf.org/html/rfc5480#section-2.1.1.1 for some
+          # pointers on different names for common curves.
+          case crv
+          when 'P-256' then 'prime256v1'
+          when 'P-384' then 'secp384r1'
+          when 'P-521' then 'secp521r1'
+          else raise 'Invalid curve provided'
+          end
+        end
+
+        private
+
+        def jwk_attrs(jwk_data, attrs)
+          attrs.map do |attr|
+            jwk_data[attr] || jwk_data[attr.to_s]
+          end
+        end
+
+        def ec_pkey(jwk_crv, jwk_x, jwk_y)
+          curve = to_openssl_curve(jwk_crv)
+
+          x_octets = decode_octets(jwk_x)
+          y_octets = decode_octets(jwk_y)
+
+          key = OpenSSL::PKey::EC.new(curve)
+
+          # The details of the `Point` instantiation are covered in:
+          # - https://docs.ruby-lang.org/en/2.4.0/OpenSSL/PKey/EC.html
+          # - https://www.openssl.org/docs/manmaster/man3/EC_POINT_new.html
+          # - https://tools.ietf.org/html/rfc5480#section-2.2
+          # - https://www.secg.org/SEC1-Ver-1.0.pdf
+          # Section 2.3.3 of the last of these references specifies that the
+          # encoding of an uncompressed point consists of the byte `0x04` followed
+          # by the x value then the y value.
+          point = OpenSSL::PKey::EC::Point.new(
+            OpenSSL::PKey::EC::Group.new(curve),
+            OpenSSL::BN.new([0x04, x_octets, y_octets].pack('Ca*a*'), 2)
+          )
+
+          key.public_key = point
+
+          key
+        end
+
+        def decode_octets(jwk_data)
+          ::Base64.urlsafe_decode64(jwk_data)
+        end
+
+        def decode_open_ssl_bn(jwk_data)
+          OpenSSL::BN.new(::Base64.urlsafe_decode64(jwk_data), BINARY)
+        end
+      end
+    end
+  end
+end

--- a/spec/jwk/ec_spec.rb
+++ b/spec/jwk/ec_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require_relative '../spec_helper'
+require 'jwt'
+
+describe JWT::JWK::EC do
+  let(:ec_key) { OpenSSL::PKey::EC.new("secp384r1").generate_key! }
+
+  describe '.new' do
+    subject { described_class.new(keypair) }
+
+    context 'when a keypair with both keys given' do
+      let(:keypair) { ec_key }
+      it 'creates an instance of the class' do
+        expect(subject).to be_a described_class
+        expect(subject.private?).to eq true
+      end
+    end
+
+    context 'when a keypair with only public key is given' do
+      let(:keypair) { ec_key.tap { |x| x.private_key = nil } }
+      it 'creates an instance of the class' do
+        expect(subject).to be_a described_class
+        expect(subject.private?).to eq false
+      end
+    end
+  end
+
+  describe '#export' do
+    subject { described_class.new(keypair).export }
+
+    context 'when keypair with private key is exported' do
+      let(:keypair) { ec_key }
+      it 'returns a hash with the both parts of the key' do
+        expect(subject).to be_a Hash
+        expect(subject).to include(:kty, :kid, :x, :y)
+
+        # Exported keys do not currently include private key info,
+        # event if the in-memory key had that information.  This is
+        # done to match the traditional behavior of RSA JWKs.
+        ## expect(subject).to include(:d)
+      end
+    end
+
+    context 'when keypair with public key is exported' do
+      let(:keypair) { ec_key.tap { |x| x.private_key = nil } }
+      it 'returns a hash with the public parts of the key' do
+        expect(subject).to be_a Hash
+        expect(subject).to include(:kty, :kid, :x, :y)
+        expect(subject).not_to include(:d)
+      end
+    end
+  end
+
+  describe '.import' do
+    subject { described_class.import(params) }
+    let(:exported_key) { described_class.new(keypair).export }
+
+    ['P-256', 'P-384', 'P-521'].each do |crv|
+      context "when crv=#{crv}" do
+        let(:openssl_curve) { JWT::JWK::EC.to_openssl_curve(crv) }
+        let(:ec_key) { OpenSSL::PKey::EC.new(openssl_curve).generate_key! }
+
+        context 'when keypair is private' do
+          let(:keypair) { ec_key }
+          let(:params) { exported_key }
+
+          it 'returns a public key' do
+            # Exporting a key exports only the public parts, so the reimported
+            # key becomes public.  This is odd, but this behavior is consistent
+            # with the traditional behavior of the RSA JWK tokens.
+            ## expect(subject.private?).to eq true
+
+            expect(subject).to be_a described_class
+            expect(subject.export).to eq(exported_key)
+          end
+        end
+
+        context 'returns a public key' do
+          let(:keypair) { ec_key.tap { |x| x.private_key = nil } }
+          let(:params) { exported_key }
+
+          it 'returns a hash with the public parts of the key' do
+            expect(subject).to be_a described_class
+            expect(subject.private?).to eq false
+            expect(subject.export).to eq(exported_key)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds support for JWKs with "kty" value "EC".  This commit includes
support for curves ("crv") "P-256", "P-384", "P-521".

For additional details on these JWKs and their contents, see
https://tools.ietf.org/html/rfc7518#section-6.2.1.

This implementation adheres closely to the pattern set by
`JWT::JWK::RSA`.  It keeps the same coding style and method names.
It also inherits a few quirks:
- It ignores any private key ("d") values when importing JWKs.
- It never emits private key ("d") values when exporting JWKs.
- An import followed by an export does not preserve the "kid" value.

These behaviors seem strange to me, but I worry that changing the
convention would be surprising and potentially dangerous to existing
users of this library.